### PR TITLE
Use new datestring in call to Log Analytics

### DIFF
--- a/src/SFA.DAS.Tools.AnalyseErrorQueues.Services/DataSinkService/laDataSink.cs
+++ b/src/SFA.DAS.Tools.AnalyseErrorQueues.Services/DataSinkService/laDataSink.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.Tools.AnalyseErrorQueues.Services.DataSinkService
 {
     public class laDataSink : IDataSink
     {
-		private static string datestring = string.Empty;
+		private string datestring = string.Empty;
 		private readonly IConfiguration _config;
 		private readonly ILogger _logger;
 
@@ -29,9 +29,7 @@ namespace SFA.DAS.Tools.AnalyseErrorQueues.Services.DataSinkService
         public void SinkMessages(string envName, string queueName, IEnumerable<sbMessageModel> messages)
         {
             // Create a hash for the API signature
-#pragma warning disable S2696 // Instance members should not write to "static" fields
-            datestring = datestring == string.Empty ? DateTime.UtcNow.ToString("r") : datestring;
-#pragma warning restore S2696 // Instance members should not write to "static" fields
+            datestring = DateTime.UtcNow.ToString("r");
 
             // Create aggregate messages to send to azure log analytics.
             var errorsByReceivingDomain =
@@ -53,6 +51,8 @@ namespace SFA.DAS.Tools.AnalyseErrorQueues.Services.DataSinkService
             var sharedKey = _config["LADataSinkSettings:sharedKey"];
             var workspaceId = _config["LADataSinkSettings:workspaceId"];
             var sendBatches = errorsByReceivingDomain.ChunkBy(chunkSize);
+
+            _logger.LogInformation($"stringToHashDateString: {datestring}");
 
             _logger.LogInformation($"chunkSize: {chunkSize}");
             _logger.LogInformation($"sendBatches: {sendBatches}");

--- a/src/SFA.DAS.Tools.AnalyseErrorQueues.Services/DataSinkService/laDataSink.cs
+++ b/src/SFA.DAS.Tools.AnalyseErrorQueues.Services/DataSinkService/laDataSink.cs
@@ -52,8 +52,6 @@ namespace SFA.DAS.Tools.AnalyseErrorQueues.Services.DataSinkService
             var workspaceId = _config["LADataSinkSettings:workspaceId"];
             var sendBatches = errorsByReceivingDomain.ChunkBy(chunkSize);
 
-            _logger.LogInformation($"stringToHashDateString: {datestring}");
-
             _logger.LogInformation($"chunkSize: {chunkSize}");
             _logger.LogInformation($"sendBatches: {sendBatches}");
 


### PR DESCRIPTION
403s were returned from Log Analytics due to an old datestring being used for Log Analytics API signature